### PR TITLE
remove unnneeded global rand.Seed logic

### DIFF
--- a/src/windows-utilities-tests/main_test.go
+++ b/src/windows-utilities-tests/main_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"math/rand"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -34,8 +33,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	var err error
 	config, err = NewConfig()
 	Expect(err).To(Succeed())
-
-	rand.Seed(time.Now().UnixNano())
 
 	boshCertPath := writeCert(config.Bosh.CaCert)
 	boshGwPrivateKeyPath := writeCert(config.Bosh.GwPrivateKey)
@@ -101,8 +98,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	var err error
 	config, err = NewConfig()
 	Expect(err).To(Succeed())
-
-	rand.Seed(time.Now().UnixNano())
 
 	boshCertPath := writeCert(config.Bosh.CaCert)
 	boshGwPrivateKeyPath := writeCert(config.Bosh.GwPrivateKey)


### PR DESCRIPTION
Calling rand.Seed globally is no longer needed. Since go 1.20 rand has been automatically seeded. go 1.20 was released in Feb 2022 and is no longer supported. See here for more details. https://pkg.go.dev/math/rand@go1.20#Seed