### PR TITLE
Fix pipeline for releases

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -3,8 +3,9 @@ resources:
   type: git
   source:
     branch: master
-    uri: git@github.com:cloudfoundry/windows-utilities-release.git
-    private_key: ((github_deploy_key_windows-utilities-release.private_key))
+    uri: https://github.com/cloudfoundry/windows-utilities-release.git
+    username: bosh-admin-bot
+    password: ((github_public_repo_token))
 
 - name: golang-release
   type: git

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -201,6 +201,7 @@ jobs:
       params:
         bump: minor
     - get: bosh-shared-ci
+    - get: bosh-integration-image
   - task: finalize-release
     file: bosh-shared-ci/tasks/release/create-final-release.yml
     image: bosh-integration-image


### PR DESCRIPTION
Uses bot account that has permissions to push commits and create releases in the pipeline. 